### PR TITLE
Upgrade to Spring Boot 3.2 / Java 17 (#36 Phase 1)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,10 +33,10 @@ jobs:
             - 3306:3306
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 8
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '8.0.442+6'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Microservice in the [WoToS](https://github.com/users/kevinthelago/projects/2) sy
 
 ## Prerequisites
 
-- Java 8 (Temurin recommended)
+- Java 17 (Temurin recommended)
 - Maven or the included `./mvnw` wrapper
 - MySQL 8 running at `localhost:3306`, user `root`, password `root`
 - Database `wotos_statistics_database` (created automatically by Hibernate on first run)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.9.RELEASE</version>
+		<version>3.2.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.wotos</groupId>
@@ -15,16 +15,12 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<java.version>17</java.version>
+		<spring-cloud.version>2023.0.1</spring-cloud.version>
+		<springdoc.version>2.3.0</springdoc.version>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.plugin</groupId>
-			<artifactId>spring-plugin-core</artifactId>
-			<version>2.0.0.RELEASE</version>
-		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
@@ -44,7 +40,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<version>2.1.9.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -56,13 +55,23 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-feign</artifactId>
-			<version>1.4.7.RELEASE</version>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>${springdoc.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>24.1.0</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -70,30 +79,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>3.0.0</version>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>3.0.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.10.Final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-			<version>RELEASE</version>
-			<scope>compile</scope>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/wotos/wotosstatisticsservice/WotosStatisticsServiceApplication.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/WotosStatisticsServiceApplication.java
@@ -6,14 +6,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableAutoConfiguration
 //@EnableDiscoveryClient
 @EnableJpaRepositories
 @EnableFeignClients
-@EnableSwagger2
 public class WotosStatisticsServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/wotos/wotosstatisticsservice/client/wot/WotAccountsFeignClient.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/client/wot/WotAccountsFeignClient.java
@@ -6,16 +6,14 @@ import com.wotos.wotosstatisticsservice.validation.constraints.Language;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
 @FeignClient(name = "WotAccountsFeignClient", url = "${env.urls.world_of_tanks_api}", configuration = FeignConfig.class)
-@RequestMapping("/account")
 public interface WotAccountsFeignClient {
 
-    @GetMapping(value = "/info/", consumes = "application/json")
+    @GetMapping(value = "/account/info/", consumes = "application/json")
     ResponseEntity<WotApiResponse<Map<Integer, WotPlayerDetails>>> getPlayerDetails(
             @RequestParam(value = "application_id") String appId,
             @RequestParam(value = "access_token", required = false) String accessToken,

--- a/src/main/java/com/wotos/wotosstatisticsservice/client/wot/WotPlayerVehiclesFeignClient.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/client/wot/WotPlayerVehiclesFeignClient.java
@@ -7,19 +7,17 @@ import com.wotos.wotosstatisticsservice.validation.constraints.Language;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.Map;
 
 @FeignClient(name = "WoTPlayerVehiclesFeignClient", url = "${env.urls.world_of_tanks_api}", configuration = FeignConfig.class)
-@RequestMapping("/tanks")
 public interface WotPlayerVehiclesFeignClient {
 
-    @GetMapping("/stats/")
+    @GetMapping("/tanks/stats/")
     ResponseEntity<WotApiResponse<Map<Integer, List<WotVehicleStatistics>>>> getPlayerVehicleStatistics(
             @RequestParam(value = "application_id") String appId,
             @RequestParam(value = "account_id") Integer[] accountIds,
@@ -31,7 +29,7 @@ public interface WotPlayerVehiclesFeignClient {
             @RequestParam(value = "tank_id") Integer[] vehicleIds
     );
 
-    @GetMapping("/achievements/")
+    @GetMapping("/tanks/achievements/")
     ResponseEntity<WotApiResponse<String>> getPlayerVehicleAchievements(
             @RequestParam(value = "application_id") String appId,
             @RequestParam(value = "account_id") Integer[] accountIds,

--- a/src/main/java/com/wotos/wotosstatisticsservice/config/SwaggerConfig.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/config/SwaggerConfig.java
@@ -1,22 +1,28 @@
 package com.wotos.wotosstatisticsservice.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 
+/**
+ * OpenAPI/Swagger configuration.
+ *
+ * <p>Springfox was replaced with SpringDoc OpenAPI during the Spring Boot 3 upgrade.
+ * SpringDoc auto-configures the {@code /v3/api-docs} endpoint and Swagger UI at
+ * {@code /swagger-ui/index.html}; this bean only supplies the API metadata.
+ */
 @Configuration
 public class SwaggerConfig {
 
     @Bean
-    public Docket swaggerApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.any())
-                .build();
+    public OpenAPI swaggerApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("WoToS Statistics Service")
+                        .description("Calculates and persists WN8 player and vehicle statistics "
+                                + "using the WoT and XVM APIs.")
+                        .version("v1"));
     }
 
 }

--- a/src/main/java/com/wotos/wotosstatisticsservice/dao/ExpectedStatistics.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/dao/ExpectedStatistics.java
@@ -1,9 +1,9 @@
 package com.wotos.wotosstatisticsservice.dao;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "expected_statistics")

--- a/src/main/java/com/wotos/wotosstatisticsservice/dao/PlayerStatisticsSnapshot.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/dao/PlayerStatisticsSnapshot.java
@@ -1,6 +1,6 @@
 package com.wotos.wotosstatisticsservice.dao;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 
 @Entity

--- a/src/main/java/com/wotos/wotosstatisticsservice/dao/VehicleStatisticsSnapshot.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/dao/VehicleStatisticsSnapshot.java
@@ -1,6 +1,6 @@
 package com.wotos.wotosstatisticsservice.dao;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 
 @Entity

--- a/src/main/java/com/wotos/wotosstatisticsservice/service/PlayerStatisticsService.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/service/PlayerStatisticsService.java
@@ -1,6 +1,6 @@
 package com.wotos.wotosstatisticsservice.service;
 
-import com.sun.istack.NotNull;
+import org.jetbrains.annotations.NotNull;
 import com.wotos.wotosstatisticsservice.dao.PlayerStatisticsSnapshot;
 import com.wotos.wotosstatisticsservice.repo.PlayerStatisticsSnapshotsRepository;
 import com.wotos.wotosstatisticsservice.repo.VehicleStatisticsSnapshotsRepository;

--- a/src/main/java/com/wotos/wotosstatisticsservice/service/VehicleStatisticsService.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/service/VehicleStatisticsService.java
@@ -1,6 +1,6 @@
 package com.wotos.wotosstatisticsservice.service;
 
-import com.sun.istack.NotNull;
+import org.jetbrains.annotations.NotNull;
 import com.wotos.wotosstatisticsservice.dao.ExpectedStatistics;
 import com.wotos.wotosstatisticsservice.dao.VehicleStatisticsSnapshot;
 import com.wotos.wotosstatisticsservice.repo.ExpectedStatisticsRepository;

--- a/src/main/java/com/wotos/wotosstatisticsservice/validation/GameModeValidator.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/validation/GameModeValidator.java
@@ -3,8 +3,8 @@ package com.wotos.wotosstatisticsservice.validation;
 import com.wotos.wotosstatisticsservice.constants.GameModes;
 import com.wotos.wotosstatisticsservice.validation.constraints.GameMode;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.EnumSet;
 
 public class GameModeValidator implements ConstraintValidator<GameMode, String[]> {

--- a/src/main/java/com/wotos/wotosstatisticsservice/validation/LanguageValidator.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/validation/LanguageValidator.java
@@ -3,8 +3,8 @@ package com.wotos.wotosstatisticsservice.validation;
 import com.wotos.wotosstatisticsservice.constants.Languages;
 import com.wotos.wotosstatisticsservice.validation.constraints.Language;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.EnumSet;
 
 public class LanguageValidator implements ConstraintValidator<Language, String> {

--- a/src/main/java/com/wotos/wotosstatisticsservice/validation/constraints/GameMode.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/validation/constraints/GameMode.java
@@ -2,8 +2,8 @@ package com.wotos.wotosstatisticsservice.validation.constraints;
 
 import com.wotos.wotosstatisticsservice.validation.GameModeValidator;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.*;
 
 @Target({ElementType.PARAMETER})

--- a/src/main/java/com/wotos/wotosstatisticsservice/validation/constraints/Language.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/validation/constraints/Language.java
@@ -2,8 +2,8 @@ package com.wotos.wotosstatisticsservice.validation.constraints;
 
 import com.wotos.wotosstatisticsservice.validation.LanguageValidator;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.*;
 
 @Target({ElementType.PARAMETER})

--- a/src/test/java/com/wotos/wotosstatisticsservice/service/PlayerStatisticsServiceTest.java
+++ b/src/test/java/com/wotos/wotosstatisticsservice/service/PlayerStatisticsServiceTest.java
@@ -100,7 +100,7 @@ public class PlayerStatisticsServiceTest {
 
         WotApiResponse<Map<Integer, WotPlayerDetails>> wotApiResponsePlayer1 = new WotApiResponse<>("", "", "", wotPlayerDetailsMapPlayer1);
         ResponseEntity<WotApiResponse<Map<Integer, WotPlayerDetails>>> wotResponseEntityPlayer1 = new ResponseEntity<>(wotApiResponsePlayer1, HttpStatus.OK);
-        when(wotAccountsFeignClient.getPlayerDetails("", "", null, null, "", accountIds)).thenReturn(wotResponseEntityPlayer1);
+        when(wotAccountsFeignClient.getPlayerDetails(eq(""), eq(""), any(), any(), eq("en"), eq(accountIds))).thenReturn(wotResponseEntityPlayer1);
 
         when(playerStatisticsSnapshotsRepository.findHighestTotalBattlesByAccountIdAndGameMode(1, "all")).thenReturn(Optional.of(0));
         when(vehicleStatisticsSnapshotsRepository.averageAverageWn8ByGameModeAndAccountId(1, "all")).thenReturn(Optional.of(1592.67f));
@@ -129,7 +129,7 @@ public class PlayerStatisticsServiceTest {
 
         Map<Integer, Map<String, PlayerStatisticsSnapshot>> playerStatisticsSnapshotsMap = playerStatisticsService.createPlayerStatisticsSnapshotsByAccountIds(accountIds);
 
-        verify(wotAccountsFeignClient, times(1)).getPlayerDetails("", "", null, null, "", accountIds);
+        verify(wotAccountsFeignClient, times(1)).getPlayerDetails(eq(""), eq(""), any(), any(), eq("en"), eq(accountIds));
         verify(playerStatisticsSnapshotsRepository, times(1)).findHighestTotalBattlesByAccountIdAndGameMode(1, "all");
         verify(playerStatisticsSnapshotsRepository, times(1)).findHighestTotalBattlesByAccountIdAndGameMode(1, "clan");
         verify(vehicleStatisticsSnapshotsRepository, times(1)).averageAverageWn8ByGameModeAndAccountId(1, "all");

--- a/src/test/java/com/wotos/wotosstatisticsservice/service/VehicleStatisticsServiceTest.java
+++ b/src/test/java/com/wotos/wotosstatisticsservice/service/VehicleStatisticsServiceTest.java
@@ -136,7 +136,7 @@ public class VehicleStatisticsServiceTest {
         Integer[] accountIds = {1};
         Integer[] vehicleIds = {1,2,3};
 
-        when(wotPlayerVehiclesFeignClient.getPlayerVehicleStatistics("", accountIds, "", null, null, null, "", vehicleIds)).thenReturn(wotResponseEntity);
+        when(wotPlayerVehiclesFeignClient.getPlayerVehicleStatistics(eq(""), eq(accountIds), eq(""), any(), any(), any(), eq("en"), eq(vehicleIds))).thenReturn(wotResponseEntity);
         when(vehicleStatisticsSnapshotsRepository.findHighestTotalBattlesByAccountIdAndVehicleId(1, 1, "all")).thenReturn(Optional.of(100));
         when(vehicleStatisticsSnapshotsRepository.findHighestTotalBattlesByAccountIdAndVehicleId(1, 2, "all")).thenReturn(Optional.of(100));
         when(vehicleStatisticsSnapshotsRepository.findHighestTotalBattlesByAccountIdAndVehicleId(1, 3, "all")).thenReturn(Optional.of(100));
@@ -146,7 +146,7 @@ public class VehicleStatisticsServiceTest {
 
         Map<Integer, Map<Integer, Map<String, VehicleStatisticsSnapshot>>> vehicleStatisticsSnapshotsMap = vehicleStatisticsService.createPlayerVehicleStatisticsSnapshots(accountIds, vehicleIds);
 
-        verify(wotPlayerVehiclesFeignClient, times(1)).getPlayerVehicleStatistics("", accountIds, "", null, null, null, "", vehicleIds);
+        verify(wotPlayerVehiclesFeignClient, times(1)).getPlayerVehicleStatistics(eq(""), eq(accountIds), eq(""), any(), any(), any(), eq("en"), eq(vehicleIds));
         verify(vehicleStatisticsSnapshotsRepository, times(1)).findHighestTotalBattlesByAccountIdAndVehicleId(1, 1, "all");
         verify(vehicleStatisticsSnapshotsRepository, times(1)).findHighestTotalBattlesByAccountIdAndVehicleId(1, 2, "all");
         verify(vehicleStatisticsSnapshotsRepository, times(1)).findHighestTotalBattlesByAccountIdAndVehicleId(1, 3, "all");

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,10 +1,11 @@
 spring:
-#  autoconfigure:
-#    exclude:
-#      org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, \
-#      org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration, \
-#      org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+  config:
+    # Spring Cloud Config (2020.0+) requires an explicit import; make it optional so
+    # tests boot without a running config server.
+    import: "optional:configserver:"
   cloud:
+    config:
+      enabled: false
     discovery:
       enabled: false
   jpa:
@@ -12,16 +13,21 @@ spring:
     generate-ddl: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
   datasource:
-    url: jdbc:mysql://localhost:3306/wotos_statistics_test_database?useSSL=false
+    url: "jdbc:mysql://localhost:3306/wotos_statistics_test_database?useSSL=false&allowPublicKeyRetrieval=true"
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+eureka:
+  client:
+    enabled: false
+
 env:
   app_id: ""
   snapshot_rate: 0
+  recent_wn8_timestamp: 0
   urls:
-    world_of_tanks_api: ""
-    xvm_expected_statistics: ""
+    world_of_tanks_api: "http://localhost"
+    xvm_expected_statistics: "http://localhost"


### PR DESCRIPTION
Closes #36.

## Summary
- **Stack**: Spring Boot `2.1.9` → `3.2.5`, Spring Cloud `Greenwich.SR3` → `2023.0.1`, Java `8` → `17`.
- **Mechanical migration**: `javax.*` → `jakarta.*` (3 entities, 2 validators, 2 constraints, 1 Feign client); Springfox → SpringDoc OpenAPI; `spring-cloud-starter-feign` → `spring-cloud-starter-openfeign`; `mysql-connector-java` → `com.mysql:mysql-connector-j`; `hibernate-validator` → `spring-boot-starter-validation`.
- **Real bugs the new stack surfaced** (the app/tests wouldn't otherwise boot): removed type-level `@RequestMapping` from `@FeignClient` interfaces (OpenFeign 4.x forbids it), added `spring.config.import: optional:configserver:` for Spring Cloud Config 2020.0+, switched the Hibernate dialect to `MySQLDialect` (Hibernate 6 dropped `MySQL8Dialect`), and added `allowPublicKeyRetrieval=true` to the test JDBC URL for MySQL 8 / connector-j.
- **Tests**: added `junit-vintage-engine` so the existing JUnit 4 tests run on the JUnit 5 platform; aligned the Mockito stub args in the two service tests with the services' real call signatures (pre-existing stub bugs that prevented those tests from ever passing).
- **CI/docs**: `setup-java` and README prerequisites bumped to JDK 17.

The JJWT / OAuth2 portions of #36 don't apply to this service (no security/JWT code).

## Test plan
- [x] `./mvnw -B clean package` against `mysql:8.0` matching CI → **Tests run: 5, Failures: 0, Errors: 0, BUILD SUCCESS**, JAR repackaged.
- [ ] CI on this PR is green.
- [ ] Smoke-run the service against a local config server + eureka after merge to confirm end-to-end startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)