### PR TITLE
Trigger CI on develop instead of dev (#37)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "develop" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "develop" ]
 
 jobs:
   build:


### PR DESCRIPTION
Slice of #37 (Phase 2 — CI Pipelines).

## Summary
- Updates `.github/workflows/maven.yml` push/pull_request triggers from the now-deleted `dev` branch to `develop` (the new integration branch from #36 merge).

## Test plan
- [ ] On merge, this PR's CI run will itself validate the trigger fires on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)