### PR TITLE
Add GlobalExceptionHandler (#33)

### DIFF
--- a/src/main/java/com/wotos/wotosstatisticsservice/exception/EntityNotFoundException.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/exception/EntityNotFoundException.java
@@ -1,0 +1,17 @@
+package com.wotos.wotosstatisticsservice.exception;
+
+/**
+ * Thrown when a requested statistics snapshot or expected-stats row is not present.
+ * Mapped to HTTP 404 by {@link GlobalExceptionHandler}.
+ */
+public class EntityNotFoundException extends RuntimeException {
+
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+
+    public EntityNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/wotos/wotosstatisticsservice/exception/ErrorResponse.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.wotos.wotosstatisticsservice.exception;
+
+import java.time.Instant;
+
+/**
+ * Standard error body returned by {@link GlobalExceptionHandler} for all
+ * exceptions surfaced from controllers.
+ */
+public record ErrorResponse(int status, String message, Instant timestamp) {
+
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message, Instant.now());
+    }
+
+}

--- a/src/main/java/com/wotos/wotosstatisticsservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.wotos.wotosstatisticsservice.exception;
+
+import feign.FeignException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+/**
+ * Centralizes HTTP error responses for the service so controllers stay free of
+ * try/catch boilerplate. Every handler returns the same {@link ErrorResponse}
+ * shape.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));
+    }
+
+    /**
+     * Covers parameter-level validation (e.g. {@code @GameMode}, {@code @Language})
+     * which the Bean Validation runtime surfaces as ConstraintViolationException
+     * rather than MethodArgumentNotValidException.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(cv -> cv.getPropertyPath() + ": " + cv.getMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message));
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ErrorResponse> handleFeign(FeignException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_GATEWAY)
+                .body(ErrorResponse.of(HttpStatus.BAD_GATEWAY.value(), "Upstream API error: " + ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+    }
+
+}


### PR DESCRIPTION
Closes #33.

## Summary
Adds three classes under `com.wotos.wotosstatisticsservice.exception`:
- `EntityNotFoundException` — custom unchecked exception for missing snapshot/expected-stats rows.
- `ErrorResponse` — Java 17 record with `status`, `message`, `timestamp`.
- `GlobalExceptionHandler` — `@RestControllerAdvice` with handlers for `EntityNotFoundException` (404), `MethodArgumentNotValidException` (400), `ConstraintViolationException` (400, covers `@GameMode`/`@Language` parameter validation), `FeignException` (502), and a fallback `Exception` (500).

Unblocks #34 (controller architecture cleanup, which removes try/catch in favor of this advice).

## Test plan
- [x] `mvn test` against `mysql:8.0` → **5/5 passing, BUILD SUCCESS**.
- [ ] CI on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)