### PR TITLE
Migrate controllers to standard architecture (#34)

### DIFF
--- a/src/main/java/com/wotos/wotosstatisticsservice/controller/PlayerStatisticsController.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/controller/PlayerStatisticsController.java
@@ -3,11 +3,14 @@ package com.wotos.wotosstatisticsservice.controller;
 import com.wotos.wotosstatisticsservice.dao.PlayerStatisticsSnapshot;
 import com.wotos.wotosstatisticsservice.service.PlayerStatisticsService;
 import com.wotos.wotosstatisticsservice.validation.constraints.GameMode;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
@@ -17,24 +20,41 @@ import java.util.Map;
 @Validated
 public class PlayerStatisticsController {
 
-    @Autowired
-    PlayerStatisticsService playerStatisticsService;
+    private final PlayerStatisticsService playerStatisticsService;
 
+    public PlayerStatisticsController(PlayerStatisticsService playerStatisticsService) {
+        this.playerStatisticsService = playerStatisticsService;
+    }
+
+    /**
+     * Returns existing player statistics snapshots grouped by account and game mode.
+     *
+     * @param accountIds WoT account IDs to fetch snapshots for
+     * @param gameModes  game modes to include (validated against {@link GameMode})
+     * @return 200 with a map of {accountId -> {gameMode -> [snapshots]}}
+     */
     @GetMapping("/stats/players")
     public ResponseEntity<Map<Integer, Map<String, List<PlayerStatisticsSnapshot>>>> getPlayerStatisticsSnapshots(
             @RequestParam(value = "accountIds") Integer[] accountIds,
             @RequestParam(value = "gameModes") @GameMode String[] gameModes
     ) {
-        return new ResponseEntity<>(playerStatisticsService.getPlayerStatisticsSnapshotsMap(accountIds, gameModes), HttpStatus.FOUND);
+        return ResponseEntity.ok(playerStatisticsService.getPlayerStatisticsSnapshotsMap(accountIds, gameModes));
     }
 
+    /**
+     * Creates fresh player statistics snapshots for the given accounts by pulling
+     * the latest data from the WoT API and computing WN8.
+     *
+     * @param accountIds WoT account IDs to snapshot
+     * @return 201 with the newly created snapshots keyed by accountId and game mode
+     */
     @PostMapping("/stats/players")
-    public ResponseEntity<HttpStatus> createPlayerStatisticsSnapshots(
+    public ResponseEntity<Map<Integer, Map<String, PlayerStatisticsSnapshot>>> createPlayerStatisticsSnapshots(
             @RequestParam(value = "accountIds") Integer[] accountIds
     ) {
-        playerStatisticsService.createPlayerStatisticsSnapshotsByAccountIds(accountIds);
-
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(playerStatisticsService.createPlayerStatisticsSnapshotsByAccountIds(accountIds));
     }
 
 }

--- a/src/main/java/com/wotos/wotosstatisticsservice/controller/VehicleStatisticsController.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/controller/VehicleStatisticsController.java
@@ -3,11 +3,14 @@ package com.wotos.wotosstatisticsservice.controller;
 import com.wotos.wotosstatisticsservice.dao.VehicleStatisticsSnapshot;
 import com.wotos.wotosstatisticsservice.service.VehicleStatisticsService;
 import com.wotos.wotosstatisticsservice.validation.constraints.GameMode;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
@@ -17,26 +20,45 @@ import java.util.Map;
 @Validated
 public class VehicleStatisticsController {
 
-    @Autowired
-    VehicleStatisticsService vehicleStatisticsService;
+    private final VehicleStatisticsService vehicleStatisticsService;
 
+    public VehicleStatisticsController(VehicleStatisticsService vehicleStatisticsService) {
+        this.vehicleStatisticsService = vehicleStatisticsService;
+    }
+
+    /**
+     * Returns existing vehicle statistics snapshots grouped by account, vehicle, and game mode.
+     *
+     * @param accountIds WoT account IDs to fetch snapshots for
+     * @param vehicleIds vehicles to filter by (optional)
+     * @param gameModes  game modes to include (validated against {@link GameMode}, optional)
+     * @return 200 with a map of {accountId -> {vehicleId -> {gameMode -> [snapshots]}}}
+     */
     @GetMapping("/stats/vehicles")
     public ResponseEntity<Map<Integer, Map<Integer, Map<String, List<VehicleStatisticsSnapshot>>>>> getPlayerVehicleStatisticsSnapshots(
             @RequestParam(value = "accountIds") Integer[] accountIds,
             @RequestParam(value = "vehicleIds", required = false) Integer[] vehicleIds,
             @RequestParam(value = "gameModes", required = false) @GameMode String[] gameModes
     ) {
-        return new ResponseEntity<>(vehicleStatisticsService.getPlayerVehicleStatisticsSnapshotsMap(accountIds, vehicleIds, gameModes), HttpStatus.OK);
+        return ResponseEntity.ok(vehicleStatisticsService.getPlayerVehicleStatisticsSnapshotsMap(accountIds, vehicleIds, gameModes));
     }
 
+    /**
+     * Creates fresh vehicle statistics snapshots for the given accounts (optionally
+     * scoped to specific vehicles) by pulling the latest data from the WoT API.
+     *
+     * @param accountIds WoT account IDs to snapshot
+     * @param vehicleIds vehicles to snapshot (optional; all vehicles if omitted)
+     * @return 201 with the newly created snapshots keyed by accountId, vehicleId, and game mode
+     */
     @PostMapping("/stats/vehicles")
-    public ResponseEntity<HttpStatus> createPlayerVehicleStatisticsSnapshots(
+    public ResponseEntity<Map<Integer, Map<Integer, Map<String, VehicleStatisticsSnapshot>>>> createPlayerVehicleStatisticsSnapshots(
             @RequestParam(value = "accountIds") Integer[] accountIds,
             @RequestParam(value = "vehicleIds", required = false) Integer[] vehicleIds
     ) {
-        vehicleStatisticsService.createPlayerVehicleStatisticsSnapshots(accountIds, vehicleIds);
-
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(vehicleStatisticsService.createPlayerVehicleStatisticsSnapshots(accountIds, vehicleIds));
     }
 
 }


### PR DESCRIPTION
Closes #34. Builds on #33 (`GlobalExceptionHandler`).

## Summary
Both controllers (`PlayerStatisticsController`, `VehicleStatisticsController`):
- **Constructor injection** replaces `@Autowired` field injection (final field, single-arg constructor).
- **Javadoc** on every public endpoint with `@param`/`@return`.

`PlayerStatisticsController` bug fixes called out in the issue:
- `GET /stats/players` now returns **200 OK** (was `HttpStatus.FOUND` / 302).
- `POST /stats/players` now returns **201 Created with the created snapshot map** (was `ResponseEntity<HttpStatus>` with no body).

Same typed-body fix applied symmetrically to `POST /stats/vehicles` (now 201 with the created snapshot map).

## Test plan
- [x] `mvn test` against `mysql:8.0` → **5/5 passing, BUILD SUCCESS**.
- [ ] CI on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)