### PR TITLE
Add JWT validation + role enforcement (#38)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 		<java.version>17</java.version>
 		<spring-cloud.version>2023.0.1</spring-cloud.version>
 		<springdoc.version>2.3.0</springdoc.version>
+		<jjwt.version>0.12.6</jjwt.version>
 	</properties>
 
 	<dependencies>
@@ -44,6 +45,27 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/src/main/java/com/wotos/wotosstatisticsservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.wotos.wotosstatisticsservice.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Validates the Bearer JWT on incoming requests and populates the
+ * SecurityContext when the token is valid. Invalid or missing tokens fall
+ * through with an empty context; downstream authorization rules in
+ * {@link SecurityConfig} decide whether the request is rejected.
+ */
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtService jwtService;
+
+    public JwtAuthenticationFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain chain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String token = header.substring(BEARER_PREFIX.length());
+            try {
+                Jws<Claims> jws = jwtService.parse(token);
+                Claims claims = jws.getPayload();
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        claims.getSubject(),
+                        null,
+                        jwtService.extractAuthorities(claims)
+                );
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (JwtException ex) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/wotos/wotosstatisticsservice/security/JwtService.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/security/JwtService.java
@@ -1,0 +1,48 @@
+package com.wotos.wotosstatisticsservice.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Parses and validates HS256 JWTs issued by the WoToS user service. Tokens
+ * are expected to carry a subject (user id) and a {@code roles} claim holding
+ * the user's role names (e.g. {@code ["ADMIN"]}); each role is mapped to a
+ * {@code ROLE_<name>} Spring Security authority.
+ */
+@Service
+public class JwtService {
+
+    private final SecretKey key;
+
+    public JwtService(@Value("${env.jwt_secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public Jws<Claims> parse(String token) {
+        return Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+    }
+
+    public Collection<? extends GrantedAuthority> extractAuthorities(Claims claims) {
+        Object raw = claims.get("roles");
+        if (raw instanceof List<?> roles) {
+            return roles.stream()
+                    .map(String::valueOf)
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                    .map(GrantedAuthority.class::cast)
+                    .toList();
+        }
+        return List.of();
+    }
+
+}

--- a/src/main/java/com/wotos/wotosstatisticsservice/security/SecurityConfig.java
+++ b/src/main/java/com/wotos/wotosstatisticsservice/security/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.wotos.wotosstatisticsservice.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Stateless JWT security: every request must carry a valid Bearer token
+ * except for the OpenAPI/Swagger docs, and write endpoints additionally
+ * require the {@code ROLE_ADMIN} authority.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/stats/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,6 +28,7 @@ env:
   app_id: ""
   snapshot_rate: 0
   recent_wn8_timestamp: 0
+  jwt_secret: "wotos-test-only-jwt-secret-min-256-bits-for-hs256-algorithm-padding"
   urls:
     world_of_tanks_api: "http://localhost"
     xvm_expected_statistics: "http://localhost"


### PR DESCRIPTION
Closes #38. Closes #4. Closes #3. Closes #1.

## Summary
First security pass for this service (no security code existed previously). Adds Spring Security 6 + JJWT 0.12 with three new classes under `com.wotos.wotosstatisticsservice.security`:

- **`JwtService`** — wraps a HS256 `SecretKey` built from `env.jwt_secret`; parses signed JWTs and maps a `roles` claim array into `ROLE_<name>` Spring Security authorities.
- **`JwtAuthenticationFilter`** — `OncePerRequestFilter` that reads the `Authorization: Bearer ...` header, validates the token via `JwtService`, and populates `SecurityContextHolder`. Invalid/missing tokens fall through with an empty context; downstream authorization decides.
- **`SecurityConfig`** — stateless `SecurityFilterChain`. CSRF disabled (Bearer-token API). Authorization rules:
  - `permitAll` on `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`
  - `POST /api/stats/**` requires `ROLE_ADMIN` (the write-endpoint role enforcement from the AC)
  - everything else requires authentication

Pom adds `spring-boot-starter-security`, `jjwt-api`, `jjwt-impl`, `jjwt-jackson` (0.12.6 — matches the version the #36 plan called out for the JJWT family).

### Scope notes vs #38 AC
- "Hardcoded DB credentials / WoT API key removed from source and rotated" — **N/A for this repo**. No hardcoded credentials exist in this codebase; the test config uses `root/root` against a local MySQL only, and the production WoT app id is sourced from `${env.app_id}` via Spring Cloud Config. Cred rotation + GitHub Actions secrets + Cloud Config encryption are config-server-repo concerns.
- "JWT validation filter" — done.
- "Role enforcement on write endpoints" — done.
- #4 / #3 / #1 are the 2022-era enhancement tickets requesting the same OAuth2 / JWT / role work and are fully subsumed by this PR.

## Test plan
- [x] `mvn test` against `mysql:8.0` → **5/5 passing, BUILD SUCCESS** (full Spring context with security boots cleanly).
- [ ] CI on this PR is green.
- [ ] End-to-end smoke: hit `POST /api/stats/players` without a token (expect 401), with a `ROLE_USER` token (expect 403), and with a `ROLE_ADMIN` token (expect 201) — to be done in the integration test phase (#40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)